### PR TITLE
improve performance of scrollwidget

### DIFF
--- a/ali/common-jei/src/main/java/com/yanny/ali/jei/compatibility/jei/JeiScrollWidget.java
+++ b/ali/common-jei/src/main/java/com/yanny/ali/jei/compatibility/jei/JeiScrollWidget.java
@@ -63,6 +63,14 @@ public class JeiScrollWidget extends AbstractScrollWidget implements IRecipeWidg
     @Override
     public void renderWidgets(GuiGraphics guiGraphics, double mouseX, double mouseY) {
         for (IRecipeWidget widget : widgets) {
+            if (widget instanceof JeiLootSlotWidget) {
+                boolean tooHigh = widget.getPosition().y() + 18 < scrollOffsetY * contentRect.height() - scrollRect.height() * scrollOffsetY;
+                boolean tooLow = widget.getPosition().y() > scrollOffsetY * contentRect.height() + scrollRect.height() - (scrollOffsetY*scrollRect.height());
+                if (tooHigh || tooLow) {
+                    continue;
+                }
+            }
+
             widget.drawWidget(guiGraphics, mouseX, mouseY);
         }
     }


### PR DESCRIPTION
this PR skips processing of `JeiLootSlotWidget`s  in `JeiScrollWidget`  that aren't visible

examples from stoneblock 4:
if you disable scissor, you can see what gets processed 
before this PR:
<img width="1918" height="1048" alt="2026-07-23_12 10 03" src="https://github.com/user-attachments/assets/bff82ba8-2aa8-4d95-8efe-fc9f9849c7cc" />

this PR
<img width="1918" height="1048" alt="2026-07-23_12 10 22" src="https://github.com/user-attachments/assets/6a41f409-fdb1-4662-be89-ed4f19e241d2" />


performance with scissor enabled
original impl:
<img width="1918" height="1048" alt="2026-07-23_12 08 58" src="https://github.com/user-attachments/assets/12041f49-98a3-48f2-8538-263296f9c430" />

this PR:
<img width="1918" height="1048" alt="2026-07-23_12 09 17" src="https://github.com/user-attachments/assets/32578842-0e04-46be-9e91-51fd25e37417" />


you could also do similar thing in `CoreListWidget` to prevent overdraw of the tree on the left
